### PR TITLE
fix pep issues with compairson operator

### DIFF
--- a/tests/test_models/test_city.py
+++ b/tests/test_models/test_city.py
@@ -92,7 +92,7 @@ class TestCity(unittest.TestCase):
         self.assertEqual(type(new_d), dict)
         self.assertFalse("_sa_instance_state" in new_d)
         for attr in c.__dict__:
-            if attr is not "_sa_instance_state":
+            if attr != "_sa_instance_state":
                 self.assertTrue(attr in new_d)
         self.assertTrue("__class__" in new_d)
 


### PR DESCRIPTION
pycode giving error with using "is not" operator.